### PR TITLE
chore(deps): cap git_clone_url version

### DIFF
--- a/pull_request-create.gemspec
+++ b/pull_request-create.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'thor'
   spec.add_runtime_dependency 'git'
   spec.add_runtime_dependency 'octokit'
-  spec.add_runtime_dependency 'git_clone_url'
+  spec.add_runtime_dependency 'git_clone_url', '>= 1.0', '< 2.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
see:
https://github.com/packsaddle/ruby-git_clone_url/issues/6
https://github.com/packsaddle/ruby-uri-ssh_git/issues/14
